### PR TITLE
Update TodoListViewController.swift

### DIFF
--- a/Todoey/Controllers/TodoListViewController.swift
+++ b/Todoey/Controllers/TodoListViewController.swift
@@ -133,6 +133,7 @@ class TodoListViewController: SwipeTableViewController {
 extension TodoListViewController: UISearchBarDelegate{
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        toDoItems = selectedCategory?.items.sorted(byKeyPath: "title", ascending: true)
         toDoItems = toDoItems?.filter("title CONTAINS[cd] %@", searchBar.text!).sorted(byKeyPath: "title", ascending: true)
         tableView.reloadData()
     }


### PR DESCRIPTION
Fix incorrect filtering if user only deletes part of the search field and writes back. Like searching for "Buy", then deleting until "b" and adding "bullets" this would search on the already filtered toDoItems